### PR TITLE
[#597] Migrating to Scylla's `native-protocol`.

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -35,7 +35,7 @@
       <version>${jackson-databind.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.datastax.oss</groupId>
+      <groupId>com.scylladb</groupId>
       <artifactId>native-protocol</artifactId>
       <version>${native-protocol.version}</version>
     </dependency>

--- a/native-protocol-json/pom.xml
+++ b/native-protocol-json/pom.xml
@@ -35,7 +35,7 @@
       <version>${jackson-databind.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.datastax.oss</groupId>
+      <groupId>com.scylladb</groupId>
       <artifactId>native-protocol</artifactId>
       <version>${native-protocol.version}</version>
     </dependency>

--- a/native-server/src/test/java/com/datastax/oss/simulacron/server/MockClient.java
+++ b/native-server/src/test/java/com/datastax/oss/simulacron/server/MockClient.java
@@ -21,6 +21,7 @@ import com.datastax.oss.protocol.internal.Compressor;
 import com.datastax.oss.protocol.internal.Frame;
 import com.datastax.oss.protocol.internal.FrameCodec;
 import com.datastax.oss.protocol.internal.Message;
+import com.datastax.oss.protocol.internal.ProtocolFeatures;
 import io.netty.bootstrap.Bootstrap;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.Channel;
@@ -31,7 +32,6 @@ import io.netty.channel.ChannelInitializer;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.local.LocalChannel;
 import java.io.Closeable;
-import java.io.IOException;
 import java.net.SocketAddress;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
@@ -54,15 +54,14 @@ public class MockClient implements Closeable {
         .handler(
             new ChannelInitializer<LocalChannel>() {
               @Override
-              protected void initChannel(LocalChannel ch) throws Exception {
+              protected void initChannel(LocalChannel ch) {
                 ch.pipeline()
-                    .addLast(new FrameEncoder(frameCodec))
+                    .addLast(new FrameEncoder(frameCodec, ProtocolFeatures.EMPTY))
                     .addLast(new TestFrameDecoder(frameCodec))
                     .addLast(
                         new ChannelInboundHandlerAdapter() {
                           @Override
-                          public void channelRead(ChannelHandlerContext ctx, Object msg)
-                              throws Exception {
+                          public void channelRead(ChannelHandlerContext ctx, Object msg) {
                             responses.offer((Frame) msg);
                           }
                         });
@@ -96,7 +95,7 @@ public class MockClient implements Closeable {
   }
 
   @Override
-  public void close() throws IOException {
+  public void close() {
     try {
       if (this.channel != null) {
         this.channel.close().sync();

--- a/native-server/src/test/java/com/datastax/oss/simulacron/server/TestFrameDecoder.java
+++ b/native-server/src/test/java/com/datastax/oss/simulacron/server/TestFrameDecoder.java
@@ -17,6 +17,7 @@ package com.datastax.oss.simulacron.server;
 
 import com.datastax.oss.protocol.internal.Frame;
 import com.datastax.oss.protocol.internal.FrameCodec;
+import com.datastax.oss.protocol.internal.ProtocolFeatures;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.LengthFieldBasedFrameDecoder;
@@ -40,7 +41,7 @@ public class TestFrameDecoder extends LengthFieldBasedFrameDecoder {
     if (buffer.readableBytes() < HEADER_LENGTH) return null;
     ByteBuf contents = (ByteBuf) super.decode(ctx, buffer);
     if (contents == null) return null;
-    return frameCodec.decode(contents);
+    return frameCodec.decode(contents, ProtocolFeatures.EMPTY);
   }
 
   @Override

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
     <junit.version>4.13.1</junit.version>
     <slf4j.version>1.7.23</slf4j.version>
     <logback.version>1.2.3</logback.version>
-    <native-protocol.version>1.4.12</native-protocol.version>
+    <native-protocol.version>1.5.2.0</native-protocol.version>
     <vertx.version>3.4.1</vertx.version>
     <jackson-databind.version>2.13.4.1</jackson-databind.version>
     <java-driver.version>3.10.0</java-driver.version>


### PR DESCRIPTION
Scope:
* Migrating from `com.datastax.oss:native-protocol` to `com.scylladb:native-protocol`
* Introducing `ProtocolFeatures` to `FrameEncoder` and `FrameDecoder`