### PR TITLE
fix: use MAVEN_GPG_PASSPHRASE env var instead of -Dgpg.passphrase CLI arg

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,7 +73,7 @@ jobs:
 
       - name: Prepare release
         env:
-          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+          MAVEN_GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
           SKIP_TESTS: ${{ inputs.skip-tests }}
           RELEASE_VERSION: ${{ inputs.release-version }}
         run: |
@@ -87,7 +87,7 @@ jobs:
       - name: Perform release
         if: inputs.dry-run == false
         env:
-          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+          MAVEN_GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
           SONATYPE_TOKEN_USERNAME: ${{ secrets.SONATYPE_TOKEN_USERNAME }}
           SONATYPE_TOKEN_PASSWORD: ${{ secrets.SONATYPE_TOKEN_PASSWORD }}
         run: |
@@ -96,7 +96,7 @@ jobs:
       - name: Perform dry release
         if: inputs.dry-run == true
         env:
-          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+          MAVEN_GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
           SONATYPE_TOKEN_USERNAME: ${{ secrets.SONATYPE_TOKEN_USERNAME }}
           SONATYPE_TOKEN_PASSWORD: ${{ secrets.SONATYPE_TOKEN_PASSWORD }}
         run: |

--- a/Makefile
+++ b/Makefile
@@ -50,16 +50,16 @@ test-unit:
 test: fmt compile verify test-unit
 
 release-prepare:
-ifeq ($(shell if [[ -n "$${GPG_PASSPHRASE}" ]]; then echo "present"; else echo "absent"; fi), absent)
-	@echo "environment variable GPG_PASSPHRASE has to be set"
+ifeq ($(shell if [[ -n "$${MAVEN_GPG_PASSPHRASE}" ]]; then echo "present"; else echo "absent"; fi), absent)
+	@echo "environment variable MAVEN_GPG_PASSPHRASE has to be set"
 	@exit 1
 endif
 	MAVEN_OPTS="$${MAVEN_OPTS}$(_RELEASE_SKIP_TESTS)" $(MVNCMD) release:prepare -Drelease.push.changes=false \
-		-Dgpg.passphrase="$${GPG_PASSPHRASE}" $(_RELEASE_VERSION_FLAG)
+		$(_RELEASE_VERSION_FLAG)
 
 .release:
-ifeq ($(shell if [[ -n "$${GPG_PASSPHRASE}" ]]; then echo "present"; else echo "absent"; fi), absent)
-	@echo "environment variable GPG_PASSPHRASE has to be set"
+ifeq ($(shell if [[ -n "$${MAVEN_GPG_PASSPHRASE}" ]]; then echo "present"; else echo "absent"; fi), absent)
+	@echo "environment variable MAVEN_GPG_PASSPHRASE has to be set"
 	@exit 1
 endif
 ifeq ($(shell if [[ -n "$${SONATYPE_TOKEN_USERNAME}" ]]; then echo "present"; else echo "absent"; fi), absent)
@@ -70,7 +70,7 @@ ifeq ($(shell if [[ -n "$${SONATYPE_TOKEN_PASSWORD}" ]]; then echo "present"; el
 	@echo "environment variable SONATYPE_TOKEN_PASSWORD has to be set"
 	@exit 1
 endif
-	MAVEN_OPTS="$${MAVEN_OPTS}$(_RELEASE_SKIP_TESTS)" $(MVNCMD) release:perform -Dgpg.passphrase=$${GPG_PASSPHRASE} $(_RELEASE_PUBLISH)
+	MAVEN_OPTS="$${MAVEN_OPTS}$(_RELEASE_SKIP_TESTS)" $(MVNCMD) release:perform $(_RELEASE_PUBLISH)
 
 release:
 	$(MAKE) .release DRY_RUN=false

--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,6 @@
     <format.validateOnly>true</format.validateOnly>
     <release.autopublish>false</release.autopublish>
     <release.push.changes>false</release.push.changes>
-    <gpg.passphrase />
   </properties>
 
   <dependencies>
@@ -125,7 +124,7 @@
             <localCheckout>true</localCheckout>
             <pushChanges>${release.push.changes}</pushChanges>
             <mavenExecutorId>forked-path</mavenExecutorId>
-            <arguments>-Dgpg.passphrase=${gpg.passphrase} -Drelease.autopublish=${release.autopublish}</arguments>
+            <arguments>-Drelease.autopublish=${release.autopublish}</arguments>
           </configuration>
           <dependencies>
             <dependency>


### PR DESCRIPTION
## Summary

Eliminates the deprecation warning produced by `maven-gpg-plugin` 3.x when passing the GPG passphrase via `-Dgpg.passphrase`:

```
[WARNING] Parameter 'passphrase' (user property 'gpg.passphrase') is deprecated:
Do not use this configuration, it may leak sensitive information.
Rely on gpg-agent or env variables instead.
...
MAVEN_GPG_PASSPHRASE environment variable for batch mode.
```

`maven-gpg-plugin` 3.x natively reads `MAVEN_GPG_PASSPHRASE` from the environment and treats the CLI property as a security risk. The forked Maven subprocess spawned by `release:perform` inherits the environment, so no explicit forwarding via `<arguments>` in `pom.xml` is needed.

## Changes

- **`Makefile`**: remove `-Dgpg.passphrase=...` from `release:prepare` and `release:perform` recipes; rename the env var guard from `GPG_PASSPHRASE` to `MAVEN_GPG_PASSPHRASE`
- **`pom.xml`**: remove `<gpg.passphrase />` property declaration; drop `-Dgpg.passphrase=${gpg.passphrase}` from `maven-release-plugin` `<arguments>` (the forked subprocess picks up `MAVEN_GPG_PASSPHRASE` from the environment automatically)
- **`.github/workflows/release.yml`**: rename `GPG_PASSPHRASE` step env var to `MAVEN_GPG_PASSPHRASE` in all three release steps (`Prepare release`, `Perform release`, `Perform dry release`); the GitHub Actions secret name (`GPG_PASSPHRASE`) is unchanged